### PR TITLE
Consistent format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ You can also specify a local file.
         console.log(data);
     });
 
+You can specify an optional list of options like so:
+
+    turnstiles('/path/to/file/turnstile_131214.txt', function(data) {
+        console.log(data);
+    }, { header: false });
+
+The only option at this point is 'header', which if set to false will output data without header.
 Issues
 ------
 

--- a/lib/streams/turnstile.js
+++ b/lib/streams/turnstile.js
@@ -16,6 +16,9 @@ function parseLine(line, callback) {
     while (line.length > 0) {
       callback({
         remote: remote,
+        station: '',
+        linename: '',
+        division: '',
         date: line.shift(),
         time: line.shift(),
         description: line.shift(),

--- a/lib/stripHeader.js
+++ b/lib/stripHeader.js
@@ -1,0 +1,5 @@
+module.exports = function(content) {
+    content = content.split('\n');
+    content.shift();
+    return content.join('\n');
+};

--- a/lib/turnstiles.js
+++ b/lib/turnstiles.js
@@ -1,10 +1,12 @@
 var TurnstileStream = require('./streams/turnstile'),
     StationStream = require('./streams/station'),
     CsvStream = require('./streams/csv'),
+    stripHeader = require('./stripHeader'),
     request = require('request'),
     fs = require('fs');
 
-module.exports = function(path, callback) {
+module.exports = function(path, callback, options) {
+    if ( ! options ) { options = {}; }
     var stream;
     if ( fs.existsSync(path) ) {
         stream = fs.createReadStream(path)
@@ -24,6 +26,9 @@ module.exports = function(path, callback) {
             content += data;
         });
         stream.on('end', function() {
+            if ( options.header === false ) {
+                content = stripHeader(content);
+            }
             callback(content);
         });
         stream.on('error', function(err) {

--- a/test/tests/turnstiles.js
+++ b/test/tests/turnstiles.js
@@ -13,8 +13,8 @@ describe('turnstiles', function() {
             data = data.split('\n');
             var header = data[0];
             var firstLine = data[1];
-            header.should.equal('remote,date,time,description,entries,exits,lat,lng,station');
-            firstLine.should.equal('R051,02-01-14,03:00:00,REGULAR,004469306,001523801,40.762796,-73.967686,LEXINGTON AVE');
+            header.should.equal('remote,station,linename,division,date,time,description,entries,exits,lat,lng');
+            firstLine.should.equal('R051,LEXINGTON AVE,,,02-01-14,03:00:00,REGULAR,004469306,001523801,40.762796,-73.967686');
             done();
         });
     });
@@ -29,6 +29,16 @@ describe('turnstiles', function() {
             firstLine.should.equal('R051,LEXINGTON AVE,NQR456,BMT,01/17/2015,03:00:00,REGULAR,0004964844,0001682142,40.762796,-73.967686');
             done();
         });
+    });
+
+    it('should optionally remove the header', function(done) {
+        var file = path.resolve('./test/data/turnstile_150124.txt');
+        turnstiles(file, function(data) {
+            data = data.split('\n');
+            var firstLine = data[0];
+            firstLine.should.equal('R051,LEXINGTON AVE,NQR456,BMT,01/17/2015,03:00:00,REGULAR,0004964844,0001682142,40.762796,-73.967686');
+            done();
+        }, { header: false });
     });
 
     it('should parse a url', function(done) {


### PR DESCRIPTION
This returns data in a consistent format. That format matches the current MTA data format (which includes things like line name and division that old data sheets don't have. For old data sheets, these columns are left blank).

This also adds an option to strip headers from the data outputs, along with tests for all the above.
